### PR TITLE
fix service url of flanT5

### DIFF
--- a/lab-materials/02/02-04-validating.ipynb
+++ b/lab-materials/02/02-04-validating.ipynb
@@ -69,7 +69,7 @@
     "        (\"gitea.gitea.svc.cluster.local\", 3000, \"Gitea\"),\n",
     "        (\"claimdb.ic-shared-db.svc.cluster.local\", 5432, \"Postgres Database\"),\n",
     "        (\"llm.ic-shared-llm.svc.cluster.local\", 8000, \"LLM Service\"),\n",
-    "        (\"ollama.ic-shared-llm.svc.cluster.local\", 11434, \"LLM Service-Ollama\"),\n",
+    "        (\"llm-flant5.ic-shared-llm.svc.cluster.local\", 3000, \"LLM Service-FlanT5\"),\n",
     "        (\"modelmesh-serving.ic-shared-img-det.svc.cluster.local\", 8033, \"ModelMesh\"),\n",
     "        # Add more services as needed\n",
     "    ]\n",


### PR DESCRIPTION
Fix for the issue https://github.com/rh-aiservices-bu/parasol-insurance/issues/35 that points to the older Ollama Service that is reverted in favor of FlanT5.

Checked in the Insurance Claim Jupyter Notebook, changing the branch of the fix created and works like a charm:

```md
Success: Minio is reachable on minio.ic-shared-minio.svc.cluster.local:9000
Success: Gitea is reachable on gitea.gitea.svc.cluster.local:3000
Success: Postgres Database is reachable on claimdb.ic-shared-db.svc.cluster.local:5432
Success: LLM Service is reachable on llm.ic-shared-llm.svc.cluster.local:8000
Success: LLM Service-FlanT5 is reachable on llm-flant5.ic-shared-llm.svc.cluster.local:3000
Success: ModelMesh is reachable on modelmesh-serving.ic-shared-img-det.svc.cluster.local:8033
```