### PR TITLE
added granite modelcar containerfile image 

### DIFF
--- a/bootstrap/granite-modelcar-image/Containerfile
+++ b/bootstrap/granite-modelcar-image/Containerfile
@@ -1,0 +1,11 @@
+# Base image for the modelcar Granite image
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4  
+
+# Install Git and Git LFS
+RUN microdnf -y install git git-lfs
+
+# Clone the Granite 7b Instruct model from Hugging Face with Git LFS
+RUN git clone https://huggingface.co/ibm-granite/granite-7b-instruct /models && rm -rf /models/.git  
+
+# Set the user to 1001
+USER 1001

--- a/bootstrap/granite-modelcar-image/README.md
+++ b/bootstrap/granite-modelcar-image/README.md
@@ -1,0 +1,15 @@
+# Granite ModelCar Image
+
+Based on the [KServe Modelcars approach](https://kserve.github.io/website/latest/modelserving/storage/oci/), the Containerfile is used to build a custom Container Image that includes the [Granite 7B Instruct](https://huggingface.co/ibm-granite/granite-7b-instruct) model.
+
+## Building the image
+
+To build the image, use the following command:
+
+`podman build -t granite-7b-instruct-modelcar:x.y .`
+
+## Using the Granite Modelcar Container Image in KServe
+
+Modelcars is not enabled by default in KServe. To enable this model serving method, it needs to be activated in the [KServe configuration](https://kserve.github.io/website/latest/modelserving/storage/oci/#enabling-modelcars).
+
+In this workshop, the modelCar is enabled in a [Job](../ic-shared-llm/job-enable-modelcar.yaml) that is deployed during the bootstrap.


### PR DESCRIPTION
This PR adds the Granite ModelCar containerfile image, along with the README.md file that explains the basics on how to build and run it.