### PR TITLE
add authorino operator

### DIFF
--- a/bootstrap/ic-rhoai-operator/kustomization.yaml
+++ b/bootstrap/ic-rhoai-operator/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 
 resources:
   # wave 0
+  - subscription-authorino.yaml
+  # wave 1
   - namespace.yaml
   - operator-group.yaml
   - subscription.yaml

--- a/bootstrap/ic-rhoai-operator/namespace.yaml
+++ b/bootstrap/ic-rhoai-operator/namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Red Hat OpenShift AI"
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: redhat-ods-operator

--- a/bootstrap/ic-rhoai-operator/operator-group.yaml
+++ b/bootstrap/ic-rhoai-operator/operator-group.yaml
@@ -4,4 +4,4 @@ metadata:
   name: rhods-operator-group
   namespace: redhat-ods-operator
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "1"

--- a/bootstrap/ic-rhoai-operator/subscription-authorino.yaml
+++ b/bootstrap/ic-rhoai-operator/subscription-authorino.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: authorino-operator
+  namespace: openshift-operators
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  channel: managed-services
+  installPlanApproval: Automatic
+  name: authorino-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/bootstrap/ic-rhoai-operator/subscription.yaml
+++ b/bootstrap/ic-rhoai-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rhods-operator
   namespace: redhat-ods-operator
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   channel: stable-2.13
   installPlanApproval: Automatic


### PR DESCRIPTION
Add the authorization operator in the ic-rhoai-operator, but in the initial deployment, force it to be installed before the RHOAI operator and, consequently, the dsci instance, to prevent race-conditions.

Solves https://github.com/rh-aiservices-bu/parasol-insurance/issues/119