### PR TITLE
✨add username to argo app name✨

### DIFF
--- a/content/modules/ROOT/pages/05-03-web-app-deploy-application.adoc
+++ b/content/modules/ROOT/pages/05-03-web-app-deploy-application.adoc
@@ -34,7 +34,7 @@ image::05/05-edit-as-yaml.png[]
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: claim-insurance-app
+  name: claim-insurance-app-{user}
 spec:
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Adding username into the Argo App name because the applications are being created in the same namespace (openshift-gitops) and when one user creates it, the others get errors "permission denied" but it is actually caused by using the same application name. username is unique enough to pass this error for now.

The alternative would be to have the ability to create applications on their user namespace and let Argo CD pick those up (app any namespace capability) but this is good enough for now ☺️